### PR TITLE
Add automatic translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Debug/
 *.user
 node_modules
 grammars.json
+*.mo
+*.pot
+*\~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ file(GLOB ${PROJECT_NAME}_src "src/*")
 ## BUILD
 ##
 
-#find_package(nlohmann_json 3.2.0 REQUIRED)
-
 add_library(${PROJECT_NAME}lib STATIC ${${PROJECT_NAME}_src})
 target_include_directories(${PROJECT_NAME}lib PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(${PROJECT_NAME}lib docopt_s wx::net wx::core wx::base wx::xrc nlohmann_json::nlohmann_json)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY := run build config test
+.PHONY := default run build test config clean justrun gdb gdb-gtk i18n-de
 
 default: build
 
@@ -26,4 +26,10 @@ gdb:
 
 gdb-gtk:
 	G_DEBUG=fatal-warnings gdb --args build/form_lang gui
+
+i18n-de:
+	build/lib/wxrc -g -o .supp_messages resources/gui.xrc
+	xgettext -C -n -k_ src/* include/* .supp_messages -p i18n/de -o pro_gramm.pot
+	msgmerge -U i18n/de/pro_gramm.po i18n/de/pro_gramm.pot
+	poedit i18n/de/pro_gramm.po
 

--- a/i18n/de/pro_gramm.po
+++ b/i18n/de/pro_gramm.po
@@ -1,0 +1,259 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-06-28 07:59+0200\n"
+"PO-Revision-Date: 2021-06-28 08:04+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.0\n"
+
+#: src/AlphabetManager.cpp:111 resources/gui.xrc:232
+msgid "Nonterminal"
+msgstr "Nichtterminal"
+
+#: src/AlphabetManager.cpp:115 resources/gui.xrc:231
+msgid "Terminal"
+msgstr "Terminal"
+
+#: src/AlphabetManager.cpp:120
+msgid "A Terminal cannot be a start symbol!"
+msgstr "Ein Terminal kann kein Startsymbol sein!"
+
+#: src/AlphabetManager.cpp:126
+msgid ""
+"Please select the type of symbol!\n"
+" Input '"
+msgstr ""
+"Bitte wählen Sie die Symbolart!\n"
+" Input '"
+
+#: src/AlphabetManager.cpp:128
+msgid "' is invalid."
+msgstr "' ist ungültig."
+
+#: src/AlphabetManager.cpp:134
+msgid "The symbol value must not be empty!"
+msgstr "Der Symbolwert kann nicht leer sein!"
+
+#: src/AlphabetManager.cpp:143 src/AlphabetManager.cpp:153
+msgid "There already exists a symbol with the value '"
+msgstr "Es gibt bereits ein Symbol mit dem Wert '"
+
+#: src/AlphabetManager.cpp:223
+msgid "Select one or multiple symbols to delete them."
+msgstr "Bitte wählen Sie ein oder mehrere Symbole zum löschen."
+
+#: src/CYKVisualisationTab.cpp:39 src/STVisualisationTab.cpp:85
+msgid "Input (grammar, word)"
+msgstr "Eingabe (Grammatik,  Wort)"
+
+#: src/CYKVisualisationTab.cpp:40 src/STVisualisationTab.cpp:86
+msgid "CNF check"
+msgstr "CNF Prüfung"
+
+#: src/CYKVisualisationTab.cpp:41 src/STVisualisationTab.cpp:88
+#: resources/gui.xrc:42
+msgid "CYK"
+msgstr "CYK"
+
+#: src/CYKVisualisationTab.cpp:43 src/STVisualisationTab.cpp:106
+#: resources/gui.xrc:49
+msgid "Syntax tree"
+msgstr "Ableitungsbaum"
+
+#: src/CYKVisualisationTab.cpp:68 src/STVisualisationTab.cpp:114
+msgid "Input grammar or input word not set"
+msgstr "Eingabegrammatik oder Eingabewort sind nicht gesetzt"
+
+#: src/CYKVisualisationTab.cpp:80 src/STVisualisationTab.cpp:126
+msgid ""
+"<b>Grammar plausibility check failed</b>\n"
+"<i>Reason</i>\n"
+msgstr ""
+"<b>Plausibilitätsprüfung der Grammatik ist fehlgeschlagen!</b>\n"
+"<i>Grund</i>\n"
+
+#: src/CYKVisualisationTab.cpp:90 src/STVisualisationTab.cpp:136
+msgid ""
+"<b>Grammar is not in CNF</b>\n"
+"<i>Reason</i>\n"
+msgstr ""
+"<b>Grammatik ist nicht in CNF!</b>\n"
+"<i>Grund!</i>\n"
+
+#: src/CYKVisualisationTab.cpp:108 src/STVisualisationTab.cpp:156
+msgid ""
+"<b>CYK algorithm failed</b>\n"
+"<i>Reason</i>\n"
+msgstr ""
+"<b>CYK Algorithmus is fehlgeschlagen!</b>\n"
+"<i>Grund</i>\n"
+
+#: src/GrammarOverviewTab.cpp:155
+msgid "Please enter a valid grammar name!"
+msgstr "Bitte geben Sie einen gültigen Namen für die Grammatik ein!"
+
+#: src/GrammarOverviewTab.cpp:163
+msgid "The grammar with the name '"
+msgstr "Die Grammatik mit dem Namen '"
+
+#: src/GrammarOverviewTab.cpp:164
+msgid "' already exists. Do you wish to override it?"
+msgstr "' existiert bereits. Möchten Sie sie überschreiben?"
+
+#: src/GrammarOverviewTab.cpp:168
+msgid "Confirmation"
+msgstr "Bestätigung"
+
+#: src/GrammarOverviewTab.cpp:201
+msgid "A grammar has to be selected to load it!"
+msgstr "Zum Laden muss eine Grammatik ausgewählt werden!"
+
+#: src/GrammarOverviewTab.cpp:204 src/GrammarOverviewTab.cpp:223
+msgid "Info"
+msgstr "Info"
+
+#: src/GrammarOverviewTab.cpp:222
+msgid "Exactly on grammar has to be selected to load it!"
+msgstr "Genau eine Grammatik muss ausgewählt werden um sie zu laden!"
+
+#: src/ProductionManager.cpp:153
+msgid "Please select a symbol for the left side of the production!"
+msgstr "Bitte wählen Sie ein Symbol für die linke Seite der Produktionsregel!"
+
+#: src/ProductionManager.cpp:170 src/ProductionManager.cpp:219
+#, c-format
+msgid "The symbol '%s' is not in the alphabet. Please add it to use it."
+msgstr ""
+"Das symbol '%s' ist nicht Teil des Alphabets. Bitte fügen Sie es hinzu, um "
+"es zu benutzen."
+
+#: src/ProductionManager.cpp:185
+msgid ""
+"A symbol has to be selected for each position. Alternatively the amount of "
+"symbols to the right of the production can be reduced."
+msgstr ""
+"Für jede Position muss ein Symbol gewählt werden. Alternativ kann die Anahl "
+"der Symbole auf der rechten Seite der Produktionsregel reduziert werden."
+
+#: resources/gui.xrc:5
+msgid "ProGramm"
+msgstr "ProGramm"
+
+#: resources/gui.xrc:32
+msgid "Visualisation"
+msgstr "Visualisierung"
+
+#: resources/gui.xrc:56
+msgid "Grammar manager"
+msgstr "Grammatikmanager"
+
+#: resources/gui.xrc:106 resources/gui.xrc:731
+msgid ""
+"<b>No diagnostics</b>\n"
+"<i>Reason</i>\n"
+"All good\n"
+"* hi"
+msgstr ""
+"<b>CYK Algorithmus is fehlgeschlagen!</b>\n"
+"<i>Grund</i>\n"
+"Keiner\n"
+"* Test"
+
+#: resources/gui.xrc:129
+msgid "Previous"
+msgstr "Zurück"
+
+#: resources/gui.xrc:146
+msgid "Next"
+msgstr "Weiter"
+
+#: resources/gui.xrc:166
+msgid "Alphabet"
+msgstr "Alphabet"
+
+#: resources/gui.xrc:174 resources/gui.xrc:684
+msgid "Productions"
+msgstr "Produktionen"
+
+#: resources/gui.xrc:182
+msgid "Overview"
+msgstr "Überblick"
+
+#: resources/gui.xrc:196
+msgid "Activate grammar!"
+msgstr "Grammatik aktivieren!"
+
+#: resources/gui.xrc:220
+msgid "Add symbol:"
+msgstr "Symbol hinzufügen:"
+
+#: resources/gui.xrc:250
+msgid "Is startsymbol"
+msgstr "Startsymbol"
+
+#: resources/gui.xrc:259
+msgid "Add symbol!"
+msgstr "Symbol hizufügen!"
+
+#: resources/gui.xrc:284 resources/gui.xrc:658
+msgid "Nonterminals"
+msgstr "Nichtterminal"
+
+#: resources/gui.xrc:309 resources/gui.xrc:632
+msgid "Terminals"
+msgstr "Terminal"
+
+#: resources/gui.xrc:330
+msgid "Delete symbols!"
+msgstr "Symbole löschen!"
+
+#: resources/gui.xrc:369
+msgid "produces"
+msgstr "produziert"
+
+#: resources/gui.xrc:415
+msgid "Add production!"
+msgstr "Produktion hinzufügen!"
+
+#: resources/gui.xrc:448
+msgid "Delete production!"
+msgstr "Produktion löschen!"
+
+#: resources/gui.xrc:502
+msgid "Check grammar!"
+msgstr "Grammatik prüfen!"
+
+#: resources/gui.xrc:539
+msgid "Name:"
+msgstr "Name:"
+
+#: resources/gui.xrc:558
+msgid "Save grammar!"
+msgstr "Grammatik speichern!"
+
+#: resources/gui.xrc:591
+msgid "Load"
+msgstr "Laden"
+
+#: resources/gui.xrc:602
+msgid "Delete"
+msgstr "Löschen"
+
+#: resources/gui.xrc:769
+msgid "Start symbol"
+msgstr "Startsymbol"
+
+#: resources/gui.xrc:803
+msgid "Input word"
+msgstr "Eingabewort"

--- a/include/GUIApplication.hpp
+++ b/include/GUIApplication.hpp
@@ -12,6 +12,7 @@ class GUIApplication : public wxApp
 {
 private:
   MainWindow* m_main_window;
+  wxLocale m_locale;
 
 public:
   /**

--- a/include/Nonterminal.hpp
+++ b/include/Nonterminal.hpp
@@ -20,7 +20,6 @@ public:
 
     std::unique_ptr<Symbol> clone() override
     {
-      //std::cout << "Cloning: " << this->identifier << "\n";
       return std::make_unique<Nonterminal>(*this);
     }
 

--- a/src/AlphabetManager.cpp
+++ b/src/AlphabetManager.cpp
@@ -108,30 +108,30 @@ void AlphabetManager::add_symbol(wxCommandEvent& evt)
 {
   bool isNonterminal;
 
-  if (this->symbol_type_selector->GetValue() == "Nonterminal")
+  if (this->symbol_type_selector->GetValue() == _("Nonterminal"))
   {
     isNonterminal = true;
   }
-  else if (this->symbol_type_selector->GetValue() == "Terminal")
+  else if (this->symbol_type_selector->GetValue() == _("Terminal"))
   {
     isNonterminal = false;
     if (this->start_symbol_selector->GetValue())
     {
-      wxMessageBox(wxT("Ein Terminal kann kein Startsymbol sein!"));
+      wxMessageBox(_("A Terminal cannot be a start symbol!"));
       return;
     }
   }
   else
   {
-    wxMessageBox(wxT("Bitte wählen Sie eine Symbolart aus!\n Eingabe '" +
-                     this->symbol_type_selector->GetValue() +
-                     "' ist nicht gültig."));
+    wxMessageBox(_("Please select the type of symbol!\n Input '") +
+                 this->symbol_type_selector->GetValue() +
+                 _("' is invalid."));
     return;
   }
 
   if (this->symbol_value_entry->GetValue() == "")
   {
-    wxMessageBox(wxT("Der Wert des Symbols darf nicht leer sein: ''"));
+    wxMessageBox(_("The symbol value must not be empty!"));
     return;
   }
 
@@ -140,8 +140,8 @@ void AlphabetManager::add_symbol(wxCommandEvent& evt)
     if (this->nonterminal_alphabet.at(i)->getIdentifier() ==
         this->symbol_value_entry->GetValue())
     {
-      wxMessageBox(wxT("Es gibt bereits ein Symbol mit dem Wert '" +
-                       this->symbol_value_entry->GetValue() + "'"));
+      wxMessageBox(_("There already exists a symbol with the value '") +
+                       this->symbol_value_entry->GetValue() + "'");
       return;
     }
   }
@@ -150,8 +150,8 @@ void AlphabetManager::add_symbol(wxCommandEvent& evt)
     if (this->terminal_alphabet.at(i)->getIdentifier() ==
         this->symbol_value_entry->GetValue())
     {
-      wxMessageBox(wxT("Es gibt bereits ein Symbol mit dem Wert '" +
-                       this->symbol_value_entry->GetValue() + "'"));
+      wxMessageBox(_("There already exists a symbol with the value '") +
+                       this->symbol_value_entry->GetValue() + "'");
       return;
     }
   }
@@ -220,7 +220,7 @@ void AlphabetManager::delete_symbol(wxCommandEvent& evt)
   Refresh();
 
   if (!deleted_a_symbol)
-    wxMessageBox(wxT("Wählen Sie ein Symbol aus, um es zu löschen!"));
+    wxMessageBox(_("Select one or multiple symbols to delete them."));
 }
 
 void AlphabetManager::on_refresh(wxPaintEvent& evt)

--- a/src/CYKVisualisationTab.cpp
+++ b/src/CYKVisualisationTab.cpp
@@ -36,11 +36,11 @@ CYKVisualisationTab::CYKVisualisationTab()
 void CYKVisualisationTab::render_input()
 {
   auto steps = std::vector<StepsDisplay::Step>{
-      {.highlight = false, .text = {"Input (grammar, word)"}},
-      {.highlight = false, .text = {"CNF check"}},
-      {.highlight = false, .text = {"CYK"}},
+      {.highlight = false, .text = {_( "Input (grammar, word)" )}},
+      {.highlight = false, .text = {_( "CNF check" )}},
+      {.highlight = false, .text = {_( "CYK" )}},
       {.highlight = false,
-       .text = {"Syntax tree"},
+       .text = {_( "Syntax tree" )},
        .on_click =
            [this] {
              auto notebook = dynamic_cast<wxNotebook*>(GetParent());
@@ -65,7 +65,7 @@ void CYKVisualisationTab::render_input()
   {
     m_table->Show(false);
     steps.at(0).highlight = true;
-    show_diagnostics("Input grammar or input word not set",
+    show_diagnostics(_( "Input grammar or input word not set" ).ToStdString(),
                      DiagnosticsLevel::info);
     m_steps->show_steps(steps);
     return;
@@ -77,7 +77,7 @@ void CYKVisualisationTab::render_input()
     m_table->Show(false);
     steps.at(0).highlight = true;
     show_diagnostics(
-        "<b>Grammar plausibility check failed</b>\n<i>Reason</i>\n" + why_not,
+        _( "<b>Grammar plausibility check failed</b>\n<i>Reason</i>\n" ).ToStdString() + why_not,
         DiagnosticsLevel::info);
     m_steps->show_steps(steps);
     return;
@@ -87,7 +87,7 @@ void CYKVisualisationTab::render_input()
   {
     m_table->Show(false);
     steps.at(1).highlight = true;
-    show_diagnostics("<b>Grammar is not in CNF</b>\n<i>Reason</i>\n" + why_not,
+    show_diagnostics(_( "<b>Grammar is not in CNF</b>\n<i>Reason</i>\n" ).ToStdString() + why_not,
                      DiagnosticsLevel::warn);
     m_steps->show_steps(steps);
     return;
@@ -105,7 +105,7 @@ void CYKVisualisationTab::render_input()
           dynamic_cast<const CYKVisualiser&>(m_visualised_thing->visualiser());
       !cyk_visualiser.success)
   {
-    show_diagnostics("<b>CYK algorithm failed</b>\n<i>Reason</i>\n" +
+    show_diagnostics(_( "<b>CYK algorithm failed</b>\n<i>Reason</i>\n" ).ToStdString() +
                          cyk_visualiser.error,
                      DiagnosticsLevel::error);
   }

--- a/src/GUIApplication.cpp
+++ b/src/GUIApplication.cpp
@@ -4,6 +4,7 @@
 
 #include "wx/image.h"
 #include "wx/init.h"
+#include "wx/language.h"
 #include "wx/xrc/xmlres.h"
 
 #include "MainWindow.hpp"
@@ -33,6 +34,11 @@ bool GUIApplication::OnInit()
     return false;
 
   wxImage::AddHandler(new wxPNGHandler{});
+
+  wxLocale::AddCatalogLookupPathPrefix("i18n");
+  if (!m_locale.Init(wxLocale::GetSystemLanguage()) ||
+      !m_locale.AddCatalog("pro_gramm"))
+    std::cerr << "Failure loading translations\n";
 
   init_xrc();
 

--- a/src/GrammarOverviewTab.cpp
+++ b/src/GrammarOverviewTab.cpp
@@ -152,21 +152,21 @@ void GrammarOverviewTab::save_grammar(wxCommandEvent& evt)
   grammar_name = this->grammar_name_entry->GetValue();
   if (!this->grammar_name_entry->IsModified())
   {
-    wxMessageBox(
-        wxString::FromUTF8("Bitte geben Sie einen gültigen Namen für die Grammatik ein!"));
+    wxMessageBox(_("Please enter a valid grammar name!"));
     return;
   }
   else
   {
     if (this->converter.grammar_exists(grammar_name))
     {
-      std::string msg_box_text = "Die Grammatik mit dem Namen '" + grammar_name;
-      msg_box_text += "' existiert bereits. Möchten Sie sie überschreiben?";
+      std::string msg_box_text =
+          _("The grammar with the name '").ToStdString() + grammar_name;
+      msg_box_text += _("' already exists. Do you wish to override it?");
       std::cout << "Constructing parent\n";
 
-      wxMessageDialog* overwrite_grammar_dialog =
-          new wxMessageDialog(this, wxString::FromUTF8(msg_box_text), "Caption",
-                              wxYES_NO | wxCENTER, wxDefaultPosition);
+      wxMessageDialog* overwrite_grammar_dialog = new wxMessageDialog(
+          this, wxString::FromUTF8(msg_box_text), _("Confirmation"),
+          wxYES_NO | wxCENTER, wxDefaultPosition);
       overwrite_grammar_dialog->Show();
       if (!(overwrite_grammar_dialog->ShowModal() == wxID_YES))
       {
@@ -198,11 +198,11 @@ void GrammarOverviewTab::load_grammar(wxCommandEvent& evt)
 
   if (grammar_names.size() == 0)
   {
-    std::string msg_box_text =
-        "Sie müssen eine Grammatik auswählen, um sie zu laden!\n";
+    std::string msg_box_text = _("A grammar has to be selected to load it!").ToStdString();
 
-    wxMessageDialog* no_grammar_selected = new wxMessageDialog(
-        this, wxString::FromUTF8(msg_box_text), "Caption", wxOK | wxCENTER, wxDefaultPosition);
+    wxMessageDialog* no_grammar_selected =
+        new wxMessageDialog(this, wxString::FromUTF8(msg_box_text), _("Info"),
+                            wxOK | wxCENTER, wxDefaultPosition);
     no_grammar_selected->ShowModal();
     return;
   }
@@ -217,8 +217,10 @@ void GrammarOverviewTab::load_grammar(wxCommandEvent& evt)
   else
   {
     wxMessageDialog* too_many_grammars = new wxMessageDialog(
-        this, wxString::FromUTF8("Sie müssen exakt eine Grammatik auswählen um sie zu laden!\n"),
-        "Caption", wxOK | wxCENTER, wxDefaultPosition);
+        this,
+        wxString::FromUTF8(
+            _("Exactly on grammar has to be selected to load it!")),
+        _("Info"), wxOK | wxCENTER, wxDefaultPosition);
     too_many_grammars->ShowModal();
     return;
   }

--- a/src/ProductionManager.cpp
+++ b/src/ProductionManager.cpp
@@ -69,8 +69,7 @@ void ProductionManager::on_create(wxWindowCreateEvent& evt)
   }
   this->rhs_sizer->Clear(true);
 
-  this->rhs_selectors.push_back(
-      new wxComboBox(rhs_container, wxID_ANY));
+  this->rhs_selectors.push_back(new wxComboBox(rhs_container, wxID_ANY));
 
   for (unsigned int i = 0; i < this->terminal_alphabet.size(); i++)
   {
@@ -151,7 +150,7 @@ void ProductionManager::add_production(wxCommandEvent& evt)
   {
 
     wxMessageBox(wxString::FromUTF8(
-        "Wählen Sie ein Symbol für die linke Seite der Produktionsregel aus!"));
+        _("Please select a symbol for the left side of the production!")));
     return;
   }
 
@@ -167,11 +166,10 @@ void ProductionManager::add_production(wxCommandEvent& evt)
   if (!lhs_exists)
   {
     wxString msg_output;
-    msg_output.Printf(wxString::FromUTF8("Das Symbol '%s"
-                                         "' ist nicht im Alphabet enthalten."
-                                         "Fügen Sie es hinzu, um es zu "
-                                         "verwenden."),
-                      this->lhs_selector->GetValue().ToStdString());
+    msg_output.Printf(
+        wxString::FromUTF8(_("The symbol '%s' is not in the alphabet. Please "
+                             "add it to use it.")),
+        this->lhs_selector->GetValue().ToStdString());
     wxMessageBox(msg_output);
     return;
   }
@@ -183,10 +181,9 @@ void ProductionManager::add_production(wxCommandEvent& evt)
   {
     if (this->rhs_selectors.at(i)->GetValue().ToStdString() == "")
     {
-      wxMessageBox(wxString::FromUTF8(
-          "Sie müssen für jede Auswahlmöglichkeit ein Symbol auswählen. "
-          "Alternativ können sie die Anzahl der Symbole auf der rechten "
-          "Seite der Produktion reduzieren."));
+      wxMessageBox(wxString::FromUTF8(_(
+          "A symbol has to be selected for each position. Alternatively the "
+          "amount of symbols to the right of the production can be reduced.")));
       return;
     }
     bool exists_in_alphabet = false;
@@ -218,11 +215,10 @@ void ProductionManager::add_production(wxCommandEvent& evt)
     if (!exists_in_alphabet)
     {
       wxString msg_output;
-      msg_output.Printf(wxString::FromUTF8("Das Symbol '%s"
-                                           "' ist nicht im Alphabet enthalten."
-                                           "Fügen Sie es hinzu, um es zu "
-                                           "verwenden."),
-                        this->rhs_selectors.at(i)->GetValue().ToStdString());
+      msg_output.Printf(
+          wxString::FromUTF8(_("The symbol '%s' is not in the alphabet. Please "
+                               "add it to use it.")),
+          this->rhs_selectors.at(i)->GetValue().ToStdString());
       wxMessageBox(msg_output);
       return;
     }
@@ -314,8 +310,7 @@ void ProductionManager::update_symbol_selectors()
     for (unsigned int i = rhs_selectors.size();
          i < this->number_of_rhs_symbols_selector->GetValue(); i++)
     {
-      this->rhs_selectors.push_back(
-          new wxComboBox(rhs_container, wxID_ANY));
+      this->rhs_selectors.push_back(new wxComboBox(rhs_container, wxID_ANY));
 
       for (unsigned int j = 0; j < this->terminal_alphabet.size(); j++)
       {
@@ -349,10 +344,10 @@ void ProductionManager::update_symbol_selectors()
                          wxSizerFlags{}.Border(wxALL, 5).CentreVertical());
   }
   rhs_container->Layout();
-  //rhs_sizer->Fit(rhs_container);
+  // rhs_sizer->Fit(rhs_container);
   rhs_container->Fit();
   rhs_container->FitInside();
-  //rhs_container->SetMinSize(rhs_container->GetSize());
+  // rhs_container->SetMinSize(rhs_container->GetSize());
 
   Layout();
   Refresh();

--- a/src/STVisualisationTab.cpp
+++ b/src/STVisualisationTab.cpp
@@ -82,10 +82,10 @@ void STVisualisationTab::draw_empty()
 void STVisualisationTab::render_input()
 {
   auto steps = std::vector<StepsDisplay::Step>{
-      {.highlight = false, .text = {"Input (grammar, word)"}},
-      {.highlight = false, .text = {"CNF check"}},
+      {.highlight = false, .text = {_("Input (grammar, word)")}},
+      {.highlight = false, .text = {_("CNF check")}},
       {.highlight = false,
-       .text = {"CYK"},
+       .text = {_("CYK")},
        .on_click =
            [this] {
              auto notebook = dynamic_cast<wxNotebook*>(GetParent());
@@ -103,7 +103,7 @@ void STVisualisationTab::render_input()
              }
              notebook->SetSelection(notebook->FindPage(cyk_tab));
            }},
-      {.highlight = false, .text = {"Syntax tree"}},
+      {.highlight = false, .text = {_("Syntax tree")}},
   };
   clear_diagnostics();
 
@@ -111,7 +111,7 @@ void STVisualisationTab::render_input()
   {
     m_visualisation_panel->Show(false);
     steps.at(0).highlight = true;
-    show_diagnostics("Input grammar or input word not set",
+    show_diagnostics(_("Input grammar or input word not set").ToStdString(),
                      DiagnosticsLevel::info);
     m_steps->show_steps(steps);
     return;
@@ -123,7 +123,7 @@ void STVisualisationTab::render_input()
     m_visualisation_panel->Show(false);
     steps.at(0).highlight = true;
     show_diagnostics(
-        "<b>Grammar plausibility check failed</b>\n<i>Reason</i>\n" + why_not,
+        _( "<b>Grammar plausibility check failed</b>\n<i>Reason</i>\n" ).ToStdString() + why_not,
         DiagnosticsLevel::info);
     m_steps->show_steps(steps);
     return;
@@ -133,7 +133,7 @@ void STVisualisationTab::render_input()
   {
     m_visualisation_panel->Show(false);
     steps.at(1).highlight = true;
-    show_diagnostics("<b>Grammar is not in CNF</b>\n<i>Reason</i>\n" + why_not,
+    show_diagnostics(_( "<b>Grammar is not in CNF</b>\n<i>Reason</i>\n" ).ToStdString() + why_not,
                      DiagnosticsLevel::warn);
     m_steps->show_steps(steps);
     return;
@@ -153,7 +153,7 @@ void STVisualisationTab::render_input()
       !cyk_visualiser.success)
   {
     m_visualisation_panel->Show(false);
-    show_diagnostics("<b>CYK algorithm failed</b>\n<i>Reason</i>\n" +
+    show_diagnostics(_( "<b>CYK algorithm failed</b>\n<i>Reason</i>\n" ).ToStdString() +
                          cyk_visualiser.error,
                      DiagnosticsLevel::error);
   }
@@ -168,7 +168,7 @@ void STVisualisationTab::on_resize(wxSizeEvent& evt)
 {
   this->Refresh();
   evt.Skip();
-} 
+}
 
 void STVisualisationTab::on_page_changed(wxBookCtrlEvent& evt)
 {


### PR DESCRIPTION
Currently the tool chain for writing translations only considers Linux
but it is possible to get it to work on Windows too (somehow ...).
To update the translation DB run `make i18n-de`. The application Poedit
has to be installed. Alternatively one can edit and compile the generated
`pro_gram.po` file manually.

The application currently detects the system language and translates all
GUI strings accordingly, defaulting to English.